### PR TITLE
fixed evalution of return value for sharealbum_generate_code()

### DIFF
--- a/include/sharealbum_functions.inc.php
+++ b/include/sharealbum_functions.inc.php
@@ -233,7 +233,7 @@ function sharealbum_create($cat_id) {
 		$sharealbum_new_user = SHAREALBUM_USER_PREFIX.sharealbum_generate_code(SHAREALBUM_USER_CODE_SUFFIX_LENGTH,true,false);
 	} while (!empty(validate_login_case($sharealbum_new_user)));
 	// Register user
-	$new_user_id = sharealbum_register_user($sharealbum_new_user,sharealbum_generate_code(SHAREALBUM_USER_PASSWORD_LENGTH, false,true));
+	$new_user_id = sharealbum_register_user($sharealbum_new_user, strlen(sharealbum_generate_code(SHAREALBUM_USER_PASSWORD_LENGTH, false,true)));
 	if (sharealbum_grant_private_category($new_user_id,$cat_id)) {
 			// TODO handle insertion error
 			// Insert code into sharealbum table


### PR DESCRIPTION
sharealbum_generate_code return string but sharealbum_register_user excepts length of string (code).
It caused problems with PHP 8.